### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/gotest.yml
+++ b/.github/workflows/gotest.yml
@@ -1,5 +1,8 @@
 name: Go Test
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ "master" ]


### PR DESCRIPTION
Potential fix for [https://github.com/found-cake/CacheStore/security/code-scanning/2](https://github.com/found-cake/CacheStore/security/code-scanning/2)

To fix the issue, add a `permissions` block to the root of the workflow file. This block will explicitly define the permissions required for the workflow, limiting the `GITHUB_TOKEN` to read-only access to repository contents. Since the workflow does not perform any write operations, the minimal permissions required are `contents: read`.

The `permissions` block should be added at the top level of the workflow file, ensuring it applies to all jobs in the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
